### PR TITLE
fix: correctly check if gource_file_filter is set

### DIFF
--- a/gource.sh
+++ b/gource.sh
@@ -67,7 +67,7 @@ fi
 if [[ $INPUT_GOURCE_START_DATE == *[!\ ]* ]]; then # Temporyry fix, check if it's a date
     OPTIONAL_PARAMS+="--start-date ${INPUT_GOURCE_START_DATE} "
 fi
-if [[ -z "$INPUT_GOURCE_FILE_FILTER" ]]; then
+if [[ ! -z "$INPUT_GOURCE_FILE_FILTER" ]]; then
     OPTIONAL_PARAMS+="--file-filter \"$INPUT_GOURCE_FILE_FILTER\" "
 fi
 


### PR DESCRIPTION
I was trying to use gource_file_filter and I noticed that it's not working. No matter what I put in there, I've always the the following output in the log file:

```
Using optional params:
```

Optional params where always empty. 

AFAIK the check if the filter is set is wrong. 

```bash
if [[ -z "$VAR" ]]; then
# ...
```

Checks for emptiness, whereas


```bash
if [[ ! -z "$VAR" ]]; then
# ...
```

checks that something is in the variable.

I can also confirm that not setting `gource_file_filter` will indeed output:

```
Using optional params: --file-filter ""
```

So, I guess in the code the check is accidentally switched from what it tried to achieve. :)